### PR TITLE
LUT-28123: Updated the EntryTypeGroup to ensure its entry Fields are initialized at creation

### DIFF
--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGroup.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGroup.java
@@ -34,12 +34,14 @@
 package fr.paris.lutece.plugins.genericattributes.service.entrytype;
 
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
+import fr.paris.lutece.plugins.genericattributes.util.GenericAttributesUtils;
 import fr.paris.lutece.portal.service.i18n.I18nService;
 import fr.paris.lutece.portal.service.message.AdminMessage;
 import fr.paris.lutece.portal.service.message.AdminMessageService;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
@@ -64,6 +66,7 @@ public abstract class AbstractEntryTypeGroup extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+        initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strFieldError = StringUtils.EMPTY;
@@ -88,5 +91,20 @@ public abstract class AbstractEntryTypeGroup extends EntryTypeService
         entry.setCSSClass( strCSSClass );
 
         return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void initCommonRequestData( Entry entry, HttpServletRequest request )
+    {
+        if ( entry.getFields( ) == null )
+        {
+            entry.setFields( new ArrayList<>( ) );
+        }
+        // Initialize the field for this EntryType's activation status
+        String strDisabled = request.getParameter( PARAMETER_DISABLED );
+        GenericAttributesUtils.createOrUpdateField( entry, IEntryTypeService.FIELD_DISABLED, null, String.valueOf( strDisabled != null ) );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/EntryTypeService.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/EntryTypeService.java
@@ -157,6 +157,14 @@ public abstract class EntryTypeService implements IEntryTypeService
         return StringUtils.EMPTY;
     }
 
+    /**
+     * Initialize the Fields common to every Generic Attribute Entry
+     * 
+     * @param entry
+     *            The Entry being processed
+     * @param request
+     *            The HTTP request
+     */
     protected void initCommonRequestData( Entry entry, HttpServletRequest request )
     {
         if ( entry.getFields( ) == null )


### PR DESCRIPTION
Making sure to initialize the field containing the activation status of the EntryType `Group` when created, by calling the `initCommonRequestData(...)` method:

- [EntryTypeService.initCommonRequestData](https://github.com/lutece-platform/lutece-genattrs-plugin-genericattributes/blob/75a4f83500d56bcbafb92f035736cef37e955f7a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/EntryTypeService.java#L160)