### PR TITLE
LUT-31559 : Short answer question, with input confirmation enabled: if

### DIFF
--- a/src/java/fr/paris/lutece/plugins/genericattributes/resources/genericattributes_messages.properties
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/resources/genericattributes_messages.properties
@@ -28,6 +28,7 @@ createEntry.labelNumberRows=Number of rows
 createEntry.labelNumberColumns=Number of columns
 createEntry.fileType=File type
 createEntry.labelChooseGalleryImage=Image gallery
+createEntry.labelUseRefListSelect=Reference list to use
 
 labelInsertGroup=Insert a grouping
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/resources/genericattributes_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/resources/genericattributes_messages_fr.properties
@@ -20,7 +20,7 @@ createEntry.labelFileMaxSize=Taille maximale du fichier (en octets)
 createEntry.labelMaxFiles=Nombre de fichiers max
 createEntry.labelConfirmFieldTitle=Titre du champ de confirmation
 createEntry.labelMaxSizeEnter=Longueur maximale du texte saisi
-createEntry.labelWidth=Longeur de la zone de texte
+createEntry.labelWidth=Longueur de la zone de texte
 createEntry.labelHeight=Hauteur de la zone de texte
 createEntry.labelComment=Commentaire
 createEntry.labelTitle=Titre
@@ -28,11 +28,12 @@ createEntry.labelNumberRows=Nombre de lignes
 createEntry.labelNumberColumns=Nombre de colonnes
 createEntry.fileType=Type de fichier
 createEntry.labelChooseGalleryImage=Galerie image
+createEntry.labelUseRefListSelect=Liste de r\u00e9f\u00e9rence \u00e0 utiliser
 
 labelInsertGroup=Ins\u00E9rer un regroupement
 
 message.myLuteceAuthentificationRequired=Authentification front-office requise
-message.numeric.field=La valeur du champs doit \u00eatre un entier positif.
+message.numeric.field=La valeur du champ doit \u00eatre un entier positif.
 message.numeric.max=Veuillez s\u00E9lectionner une valeur inf\u00E9rieure ou \u00E9gale \u00e0 {0}
 message.numeric.min=Veuillez s\u00E9lectionner une valeur sup\u00E9rieure ou \u00E9gale \u00e0 {0}
 message.errorXssField=Les caract\u00E8res &lt; &gt; # &amp; et &quot; sont interdits.

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeArray.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeArray.java
@@ -63,6 +63,15 @@ public abstract class AbstractEntryTypeArray extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -92,6 +101,11 @@ public abstract class AbstractEntryTypeArray extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
         else
@@ -101,6 +115,10 @@ public abstract class AbstractEntryTypeArray extends EntryTypeService
                         I18nService.getLocalizedString( FIELD_NUMBER_ROWS, locale )
                 };
 
+                if( StringUtils.isNotBlank( errorReturnUrl ) )
+                {
+                	return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+                }
                 return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
             }
             else
@@ -110,6 +128,10 @@ public abstract class AbstractEntryTypeArray extends EntryTypeService
                             I18nService.getLocalizedString( FIELD_NUMBER_COLUMNS, locale )
                     };
 
+                    if( StringUtils.isNotBlank( errorReturnUrl ) )
+                    {
+                    	return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+                    }
                     return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
                 }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeCamera.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeCamera.java
@@ -82,6 +82,15 @@ public abstract class AbstractEntryTypeCamera extends AbstractEntryTypeImage
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -121,6 +130,10 @@ public abstract class AbstractEntryTypeCamera extends AbstractEntryTypeImage
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -163,6 +176,10 @@ public abstract class AbstractEntryTypeCamera extends AbstractEntryTypeImage
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeCartography.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeCartography.java
@@ -116,6 +116,15 @@ public abstract class AbstractEntryTypeCartography extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -140,6 +149,10 @@ public abstract class AbstractEntryTypeCartography extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeCheckBox.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeCheckBox.java
@@ -66,6 +66,15 @@ public abstract class AbstractEntryTypeCheckBox extends AbstractEntryTypeChoice
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -92,12 +101,20 @@ public abstract class AbstractEntryTypeCheckBox extends AbstractEntryTypeChoice
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         strFieldError = createFieldsUseRefList( entry, request );
         if ( StringUtils.isNotBlank( strFieldError ) )
         {
+        	if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+        		return AdminMessageService.getMessageUrl( request, strFieldError, ERROR_FIELD_REF_LIST, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, strFieldError, ERROR_FIELD_REF_LIST, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeComment.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeComment.java
@@ -64,6 +64,15 @@ public abstract class AbstractEntryTypeComment extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strComment = request.getParameter( PARAMETER_COMMENT );
@@ -83,6 +92,10 @@ public abstract class AbstractEntryTypeComment extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeDate.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeDate.java
@@ -67,6 +67,15 @@ public abstract class AbstractEntryTypeDate extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -92,6 +101,11 @@ public abstract class AbstractEntryTypeDate extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
+
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -105,6 +119,11 @@ public abstract class AbstractEntryTypeDate extends EntryTypeService
                 Object [ ] messageArgs = new Object [ ] {
                         DateUtil.ISO_PATTERN_DATE
                 };
+                
+                if( StringUtils.isNotBlank( errorReturnUrl ) )
+                {
+                	return AdminMessageService.getMessageUrl( request, MESSAGE_ILLOGICAL_DATE, messageArgs, errorReturnUrl, AdminMessage.TYPE_STOP );
+                }
                 return AdminMessageService.getMessageUrl( request, MESSAGE_ILLOGICAL_DATE, messageArgs, AdminMessage.TYPE_STOP );
             }
         }

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGalleryImage.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGalleryImage.java
@@ -167,6 +167,15 @@ public abstract class AbstractEntryTypeGalleryImage extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strHelpMessage = ( request.getParameter( PARAMETER_HELP_MESSAGE ) != null ) ? request.getParameter( PARAMETER_HELP_MESSAGE ).trim( ) : null;
@@ -177,7 +186,7 @@ public abstract class AbstractEntryTypeGalleryImage extends EntryTypeService
         String strOnlyDisplayInBack = request.getParameter( PARAMETER_ONLY_DISPLAY_IN_BACK );
         String strIndexed = request.getParameter( PARAMETER_INDEXED );
 
-        String strError = checkEntryData( request, locale );
+        String strError = checkEntryData( request, locale, errorReturnUrl );
 
         if ( StringUtils.isNotBlank( strError ) )
         {
@@ -226,7 +235,7 @@ public abstract class AbstractEntryTypeGalleryImage extends EntryTypeService
      *            the locale
      * @return the error message url if there is an error, an empty string otherwise
      */
-    private static String checkEntryData( HttpServletRequest request, Locale locale )
+    private static String checkEntryData( HttpServletRequest request, Locale locale, String errorReturnUrl )
     {
         String strTitle = request.getParameter( IEntryTypeService.PARAMETER_TITLE );
         String strFieldError = StringUtils.EMPTY;
@@ -248,6 +257,10 @@ public abstract class AbstractEntryTypeGalleryImage extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, IEntryTypeService.MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, IEntryTypeService.MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGeolocation.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGeolocation.java
@@ -120,6 +120,15 @@ public abstract class AbstractEntryTypeGeolocation extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -143,6 +152,11 @@ public abstract class AbstractEntryTypeGeolocation extends EntryTypeService
             Object [ ] tabRequiredFields = {
                     I18nService.getLocalizedString( strFieldError, locale )
             };
+
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
 
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGroup.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeGroup.java
@@ -66,6 +66,15 @@ public abstract class AbstractEntryTypeGroup extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -83,6 +92,10 @@ public abstract class AbstractEntryTypeGroup extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeNumber.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeNumber.java
@@ -65,6 +65,15 @@ public abstract class AbstractEntryTypeNumber extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -95,6 +104,11 @@ public abstract class AbstractEntryTypeNumber extends EntryTypeService
             Object [ ] tabRequiredFields = {
                     I18nService.getLocalizedString( strFieldError, locale )
             };
+
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
 
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeNumbering.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeNumbering.java
@@ -65,6 +65,15 @@ public abstract class AbstractEntryTypeNumbering extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -85,6 +94,10 @@ public abstract class AbstractEntryTypeNumbering extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeRadioButton.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeRadioButton.java
@@ -62,6 +62,15 @@ public abstract class AbstractEntryTypeRadioButton extends AbstractEntryTypeChoi
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+	/**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -87,13 +96,26 @@ public abstract class AbstractEntryTypeRadioButton extends AbstractEntryTypeChoi
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
+
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         strFieldError = createFieldsUseRefList( entry, request );
         if ( StringUtils.isNotBlank( strFieldError ) )
         {
-            return AdminMessageService.getMessageUrl( request, strFieldError, ERROR_FIELD_REF_LIST, AdminMessage.TYPE_STOP );
+        	Object [ ] tabRequiredFields = {
+                    I18nService.getLocalizedString( ERROR_FIELD_REF_LIST, locale )
+            };
+        	
+        	if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+        		return AdminMessageService.getMessageUrl( request, strFieldError, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
+        	return AdminMessageService.getMessageUrl( request, strFieldError, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         entry.setCode( strCode );

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSelect.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSelect.java
@@ -61,6 +61,15 @@ public abstract class AbstractEntryTypeSelect extends AbstractEntryTypeChoice
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+	/**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -84,13 +93,25 @@ public abstract class AbstractEntryTypeSelect extends AbstractEntryTypeChoice
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         strFieldError = createFieldsUseRefList( entry, request );
         if ( StringUtils.isNotBlank( strFieldError ) )
         {
-            return AdminMessageService.getMessageUrl( request, strFieldError, ERROR_FIELD_REF_LIST, AdminMessage.TYPE_STOP );
+        	Object [ ] tabRequiredFields = {
+                    I18nService.getLocalizedString( ERROR_FIELD_REF_LIST, locale )
+            };
+        	
+        	if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+        		return AdminMessageService.getMessageUrl( request, strFieldError, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
+            return AdminMessageService.getMessageUrl( request, strFieldError, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         entry.setCode( strCode );

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSelectOrder.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSelectOrder.java
@@ -63,6 +63,15 @@ public abstract class AbstractEntryTypeSelectOrder extends AbstractEntryTypeChoi
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+	/**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -87,13 +96,25 @@ public abstract class AbstractEntryTypeSelectOrder extends AbstractEntryTypeChoi
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         strFieldError = createFieldsUseRefList( entry, request );
         if ( StringUtils.isNotBlank( strFieldError ) )
         {
-            return AdminMessageService.getMessageUrl( request, strFieldError, ERROR_FIELD_REF_LIST, AdminMessage.TYPE_STOP );
+        	Object [ ] tabRequiredFields = {
+                    I18nService.getLocalizedString( ERROR_FIELD_REF_LIST, locale )
+            };
+        	
+        	if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+        		return AdminMessageService.getMessageUrl( request, strFieldError, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
+            return AdminMessageService.getMessageUrl( request, strFieldError, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
         entry.setCode( strCode );

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSelectSQL.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSelectSQL.java
@@ -64,6 +64,15 @@ public abstract class AbstractEntryTypeSelectSQL extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+	
+	/**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -85,6 +94,10 @@ public abstract class AbstractEntryTypeSelectSQL extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -114,6 +127,10 @@ public abstract class AbstractEntryTypeSelectSQL extends EntryTypeService
                     strErrorMsg
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_INVALID_SQL_QUERY, tabErrorSQLMsg, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_INVALID_SQL_QUERY, tabErrorSQLMsg, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSession.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSession.java
@@ -67,6 +67,15 @@ public abstract class AbstractEntryTypeSession extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -91,6 +100,10 @@ public abstract class AbstractEntryTypeSession extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSlot.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeSlot.java
@@ -28,6 +28,15 @@ public abstract class AbstractEntryTypeSlot extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -49,6 +58,10 @@ public abstract class AbstractEntryTypeSlot extends EntryTypeService
         {
             Object[] tabRequiredFields = { I18nService.getLocalizedString( strFieldError, locale ) };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeTelephoneNumber.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeTelephoneNumber.java
@@ -70,8 +70,20 @@ public abstract class AbstractEntryTypeTelephoneNumber extends EntryTypeService
     private static final String MESSAGE_UNKNOWN_DEFAULT_REGION = "genericattributes.message.error.unknown.default.region";
     private static final String PROPERTY_DEFAULT_DEFAULT_REGION = "genericattributes.telephoneNumber.default.default.region";
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
+    {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
     {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -100,6 +112,10 @@ public abstract class AbstractEntryTypeTelephoneNumber extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -119,6 +135,12 @@ public abstract class AbstractEntryTypeTelephoneNumber extends EntryTypeService
         {
             if ( !PhoneNumberUtil.getInstance( ).getSupportedRegions( ).contains( strDefaultRegion ) )
             {
+            	if( StringUtils.isNotBlank( errorReturnUrl ) )
+                {
+            		return AdminMessageService.getMessageUrl( request, MESSAGE_UNKNOWN_DEFAULT_REGION, new Object [ ] {
+                            strDefaultRegion
+                    }, errorReturnUrl, AdminMessage.TYPE_STOP );
+                }
                 return AdminMessageService.getMessageUrl( request, MESSAGE_UNKNOWN_DEFAULT_REGION, new Object [ ] {
                         strDefaultRegion
                 }, AdminMessage.TYPE_STOP );

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeText.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeText.java
@@ -77,6 +77,15 @@ public abstract class AbstractEntryTypeText extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
         String strTitle = request.getParameter( PARAMETER_TITLE );
@@ -130,6 +139,10 @@ public abstract class AbstractEntryTypeText extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -160,6 +173,10 @@ public abstract class AbstractEntryTypeText extends EntryTypeService
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeTextArea.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeTextArea.java
@@ -66,6 +66,15 @@ public abstract class AbstractEntryTypeTextArea extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strCode = request.getParameter( PARAMETER_ENTRY_CODE );
@@ -110,7 +119,11 @@ public abstract class AbstractEntryTypeTextArea extends EntryTypeService
             Object [ ] tabRequiredFields = {
                     I18nService.getLocalizedString( strFieldError, locale )
             };
-
+            
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -152,7 +165,11 @@ public abstract class AbstractEntryTypeTextArea extends EntryTypeService
             Object [ ] tabRequiredFields = {
                     I18nService.getLocalizedString( strFieldError, locale )
             };
-
+            
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, MESSAGE_NUMERIC_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeUpload.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeUpload.java
@@ -298,6 +298,15 @@ public abstract class AbstractEntryTypeUpload extends EntryTypeService
     @Override
     public String getRequestData( Entry entry, HttpServletRequest request, Locale locale )
     {
+    	return getRequestData( entry, request, locale, null );
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         initCommonRequestData( entry, request );
         String strTitle = request.getParameter( PARAMETER_TITLE );
         String strHelpMessage = ( request.getParameter( PARAMETER_HELP_MESSAGE ) != null ) ? request.getParameter( PARAMETER_HELP_MESSAGE ).trim( ) : null;
@@ -308,7 +317,7 @@ public abstract class AbstractEntryTypeUpload extends EntryTypeService
         String strOnlyDisplayInBack = request.getParameter( PARAMETER_ONLY_DISPLAY_IN_BACK );
         String strIndexed = request.getParameter( PARAMETER_INDEXED );
 
-        String strError = FileAttributesUtils.checkEntryData( request, locale );
+        String strError = FileAttributesUtils.checkEntryData( request, locale, errorReturnUrl );
 
         if ( StringUtils.isNotBlank( strError ) )
         {

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/EntryTypeService.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/EntryTypeService.java
@@ -71,6 +71,15 @@ public abstract class EntryTypeService implements IEntryTypeService
      * {@inheritDoc}
      */
     @Override
+    public String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public GenericAttributeError getResponseData( Entry entry, HttpServletRequest request, List<Response> listResponse, Locale locale )
     {
         return null;

--- a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/IEntryTypeService.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/IEntryTypeService.java
@@ -224,6 +224,22 @@ public interface IEntryTypeService
     String getRequestData( Entry entry, HttpServletRequest request, Locale locale );
 
     /**
+     * Get the request data
+     * 
+     * @param entry
+     *            The entry
+     * @param request
+     *            HttpRequest
+     * @param locale
+     *            the locale
+     * @param errorReturnUrl
+     *            url to go to after displaying a message when an error occurs
+     * @return null if all data required are in the request else the url of jsp error
+     */
+    String getRequestData( Entry entry, HttpServletRequest request, Locale locale, String errorReturnUrl );
+
+    
+    /**
      * Generate the list of responses associated with the given entry from the request, and saved it into the Entry object.
      * 
      * @param entry

--- a/src/java/fr/paris/lutece/plugins/genericattributes/util/FileAttributesUtils.java
+++ b/src/java/fr/paris/lutece/plugins/genericattributes/util/FileAttributesUtils.java
@@ -170,6 +170,20 @@ public final class FileAttributesUtils
      */
     public static String checkEntryData( HttpServletRequest request, Locale locale )
     {
+    	return checkEntryData( request, locale, null );
+    }
+    
+    /**
+     * Check the entry data
+     * 
+     * @param request
+     *            the HTTP request
+     * @param locale
+     *            the locale
+     * @return the error message url if there is an error, an empty string otherwise
+     */
+    public static String checkEntryData( HttpServletRequest request, Locale locale, String errorReturnUrl )
+    {
         String strTitle = request.getParameter( IEntryTypeService.PARAMETER_TITLE );
         String strMaxFiles = request.getParameter( IEntryTypeService.PARAMETER_MAX_FILES );
         String strFileMaxSize = request.getParameter( IEntryTypeService.PARAMETER_FILE_MAX_SIZE );
@@ -196,6 +210,10 @@ public final class FileAttributesUtils
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, IEntryTypeService.MESSAGE_MANDATORY_FIELD, tabRequiredFields,errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, IEntryTypeService.MESSAGE_MANDATORY_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 
@@ -215,6 +233,10 @@ public final class FileAttributesUtils
                     I18nService.getLocalizedString( strFieldError, locale )
             };
 
+            if ( StringUtils.isNotBlank( errorReturnUrl ) )
+            {
+            	return AdminMessageService.getMessageUrl( request, IEntryTypeService.MESSAGE_NUMERIC_FIELD, tabRequiredFields, errorReturnUrl, AdminMessage.TYPE_STOP );
+            }
             return AdminMessageService.getMessageUrl( request, IEntryTypeService.MESSAGE_NUMERIC_FIELD, tabRequiredFields, AdminMessage.TYPE_STOP );
         }
 


### PR DESCRIPTION
the confirmation field title is empty, a first message is displayed then an error is displayed (ERR_CACHE_MISS page).